### PR TITLE
fix: velocita default URL on index.html

### DIFF
--- a/proxy/templates/index.html.erb
+++ b/proxy/templates/index.html.erb
@@ -1,6 +1,6 @@
 <%
 
-velocita_url = ENV["VELOCITA_URL"]
+velocita_url = ENV['VELOCITA_URL'] || 'http://localhost'
 
 mirrors = {}
 ENV.keys.map { |key| key.to_s }


### PR DESCRIPTION
If `VELOCITA_URL` is not set, it won't fallback to `http://localhost`, resulting in incomplete instructions being displayed on index.html. This PR fixes this issue. 